### PR TITLE
fix: add browser-compatible logger for Svelte components

### DIFF
--- a/examples/svelte/simple-backup-restore/src/lib/StorachaAuth.svelte
+++ b/examples/svelte/simple-backup-restore/src/lib/StorachaAuth.svelte
@@ -42,7 +42,7 @@
   export let compact = false;
   export let enableSeedAuth = true;
   export let enableEmailAuth = true;
-  import { logger } from "../../../../lib/logger.js";
+  import { logger } from "./logger.js";
 
   // Authentication state
   let isAuthenticated = false;

--- a/examples/svelte/simple-backup-restore/src/lib/StorachaTestWithWebAuthn.svelte
+++ b/examples/svelte/simple-backup-restore/src/lib/StorachaTestWithWebAuthn.svelte
@@ -84,7 +84,7 @@
     Checkmark,
     Warning,
   } from "carbon-icons-svelte";
-  import { logger } from "../../../../lib/logger.js";
+  import { logger } from "./logger.js";
 
   // Storacha authentication state
   let storachaAuthenticated = false;

--- a/examples/svelte/simple-backup-restore/src/lib/logger.js
+++ b/examples/svelte/simple-backup-restore/src/lib/logger.js
@@ -1,0 +1,166 @@
+const getLogLevel = () => {
+  if (typeof window !== 'undefined' && window.localStorage) {
+    return localStorage.getItem('LOG_LEVEL') || 'info';
+  }
+  return 'info';
+};
+
+const LOG_LEVELS = {
+  trace: 10,
+  debug: 20,
+  info: 30,
+  warn: 40,
+  error: 50,
+  fatal: 60,
+  silent: 100
+};
+
+class BrowserLogger {
+  constructor(config = {}) {
+    this.level = config.level || getLogLevel();
+    this.bindings = config.bindings || {};
+    this.name = config.name || '';
+  }
+
+  get levelValue() {
+    return LOG_LEVELS[this.level] || LOG_LEVELS.info;
+  }
+
+  shouldLog(level) {
+    return LOG_LEVELS[level] >= this.levelValue;
+  }
+
+  formatMessage(level, obj, msg) {
+    const timestamp = new Date().toISOString();
+    const prefix = `[${timestamp}] ${level.toUpperCase()}`;
+    
+    if (this.name) {
+      return `${prefix} [${this.name}]`;
+    }
+    return prefix;
+  }
+
+  log(level, objOrMsg, msg) {
+    if (!this.shouldLog(level)) return;
+
+    let logObj = {};
+    let logMsg = '';
+
+    if (typeof objOrMsg === 'string') {
+      logMsg = objOrMsg;
+    } else if (typeof objOrMsg === 'object' && objOrMsg !== null) {
+      logObj = { ...this.bindings, ...objOrMsg };
+      logMsg = msg || '';
+    } else {
+      logMsg = String(objOrMsg);
+    }
+
+    const prefix = this.formatMessage(level, logObj, logMsg);
+    const hasObject = Object.keys(logObj).length > 0;
+
+    const consoleMethod = level === 'error' || level === 'fatal' ? 'error' :
+                         level === 'warn' ? 'warn' :
+                         level === 'debug' || level === 'trace' ? 'debug' :
+                         'log';
+
+    if (hasObject) {
+      console[consoleMethod](prefix, logMsg, logObj);
+    } else {
+      console[consoleMethod](prefix, logMsg);
+    }
+  }
+
+  trace(objOrMsg, msg) {
+    this.log('trace', objOrMsg, msg);
+  }
+
+  debug(objOrMsg, msg) {
+    this.log('debug', objOrMsg, msg);
+  }
+
+  info(objOrMsg, msg) {
+    this.log('info', objOrMsg, msg);
+  }
+
+  warn(objOrMsg, msg) {
+    this.log('warn', objOrMsg, msg);
+  }
+
+  error(objOrMsg, msg) {
+    this.log('error', objOrMsg, msg);
+  }
+
+  fatal(objOrMsg, msg) {
+    this.log('fatal', objOrMsg, msg);
+  }
+
+  child(bindings) {
+    return new BrowserLogger({
+      level: this.level,
+      bindings: { ...this.bindings, ...bindings },
+      name: bindings.name || this.name
+    });
+  }
+}
+
+export const logger = new BrowserLogger();
+
+
+export function createChildLogger(bindings) {
+  return logger.child(bindings);
+}
+
+export const logUtils = {
+  functionEntry: (functionName, params = {}, childLogger = logger) => {
+    childLogger.debug(
+      { function: functionName, params },
+      `Entering ${functionName}`
+    );
+  },
+
+  functionExit: (functionName, result, childLogger = logger) => {
+    childLogger.debug(
+      { function: functionName, result },
+      `Exiting ${functionName}`
+    );
+  },
+
+
+  progress: (operation, current, total, childLogger = logger) => {
+    const percentage = Math.round((current / total) * 100);
+    childLogger.info(
+      {
+        operation,
+        progress: { current, total, percentage },
+      },
+      `${operation}: ${current}/${total} (${percentage}%)`
+    );
+  },
+
+
+  timing: (operation, startTime, childLogger = logger) => {
+    const duration = Date.now() - startTime;
+    childLogger.info(
+      { operation, duration },
+      `${operation} completed in ${duration}ms`
+    );
+  },
+};
+
+
+export function setLogLevel(level) {
+  logger.level = level;
+  if (typeof window !== 'undefined' && window.localStorage) {
+    localStorage.setItem('LOG_LEVEL', level);
+  }
+}
+
+export function disableLogging() {
+  logger.level = 'silent';
+}
+
+export function enableLogging(level = 'info') {
+  logger.level = level;
+}
+
+export default logger;

--- a/examples/svelte/simple-backup-restore/src/lib/storacha-backup.js
+++ b/examples/svelte/simple-backup-restore/src/lib/storacha-backup.js
@@ -17,7 +17,7 @@ import * as ed25519 from "@ucanto/principal/ed25519";
 import { generateMnemonic, mnemonicToSeedSync } from "@scure/bip39";
 import { wordlist as english } from "@scure/bip39/wordlists/english";
 import { createHash } from "crypto";
-import { logger } from "../../../../lib/logger.js";
+import { logger } from "./logger.js";
 
 /**
  * Initialize Storacha client with key/proof credentials

--- a/examples/svelte/simple-backup-restore/src/lib/theme.js
+++ b/examples/svelte/simple-backup-restore/src/lib/theme.js
@@ -1,5 +1,5 @@
 import { writable } from "svelte/store";
-import { logger } from "../../../../lib/logger.js";
+import { logger } from "./logger.js";
 
 // Create a writable store for the theme
 function createThemeStore() {

--- a/examples/svelte/simple-backup-restore/src/lib/utils.js
+++ b/examples/svelte/simple-backup-restore/src/lib/utils.js
@@ -14,7 +14,7 @@ import { createHelia } from "helia";
 import { createOrbitDB } from "@orbitdb/core";
 import { LevelBlockstore } from "blockstore-level";
 import { LevelDatastore } from "datastore-level";
-import { logger } from "../../../../lib/logger.js";
+import { logger } from "./logger.js";
 
 /**
  * Clean up OrbitDB directories

--- a/examples/svelte/simple-backup-restore/src/routes/test-logger/+page.svelte
+++ b/examples/svelte/simple-backup-restore/src/routes/test-logger/+page.svelte
@@ -1,0 +1,88 @@
+<script>
+  import { onMount } from 'svelte';
+  import { logger, setLogLevel, logUtils } from '$lib/logger.js';
+  import { Button, Select, SelectItem } from 'carbon-components-svelte';
+
+  let logLevel = 'info';
+  let messages = [];
+
+  onMount(() => {
+    // Set initial log level
+    setLogLevel(logLevel);
+    
+    // Test the logger
+    testLogger();
+  });
+
+  function testLogger() {
+    messages = [];
+    
+    // Test different log levels
+    logger.trace('This is a trace message');
+    logger.debug('This is a debug message', { extra: 'data' });
+    logger.info('This is an info message');
+    logger.warn('This is a warning message');
+    logger.error('This is an error message');
+    
+    // Test child logger
+    const childLogger = logger.child({ component: 'TestComponent' });
+    childLogger.info('Message from child logger');
+    
+    // Test log utils
+    logUtils.functionEntry('testFunction', { param1: 'value1' });
+    logUtils.functionExit('testFunction', { result: 'success' });
+    logUtils.progress('Processing', 50, 100);
+    
+    const startTime = Date.now();
+    setTimeout(() => {
+      logUtils.timing('TestOperation', startTime);
+    }, 100);
+    
+    messages = [
+      'Logger test complete! Check the browser console for output.',
+      `Current log level: ${logLevel}`,
+      'Try changing the log level and running the test again.'
+    ];
+  }
+
+  function handleLogLevelChange() {
+    setLogLevel(logLevel);
+    testLogger();
+  }
+</script>
+
+<div style="padding: 2rem;">
+  <h1>Logger Test Page</h1>
+  
+  <div style="margin: 2rem 0;">
+    <Select bind:selected={logLevel} on:change={handleLogLevelChange} labelText="Log Level">
+      <SelectItem value="trace" text="Trace" />
+      <SelectItem value="debug" text="Debug" />
+      <SelectItem value="info" text="Info" />
+      <SelectItem value="warn" text="Warn" />
+      <SelectItem value="error" text="Error" />
+      <SelectItem value="silent" text="Silent" />
+    </Select>
+  </div>
+  
+  <Button on:click={testLogger}>Run Logger Test</Button>
+  
+  <div style="margin-top: 2rem;">
+    <h3>Test Results:</h3>
+    <ul>
+      {#each messages as message}
+        <li>{message}</li>
+      {/each}
+    </ul>
+  </div>
+  
+  <div style="margin-top: 2rem; padding: 1rem; background: #f4f4f4; border-radius: 4px;">
+    <p><strong>Instructions:</strong></p>
+    <ol>
+      <li>Open the browser Developer Console (F12)</li>
+      <li>Click "Run Logger Test" to see log messages</li>
+      <li>Change the log level to see different levels of output</li>
+      <li>Try "Debug" to see all messages, or "Error" to see only errors</li>
+    </ol>
+  </div>
+</div>


### PR DESCRIPTION
Closes #33 

### Fix: Browser-Compatible Logger for Svelte Examples

Svelte examples were failing because they imported the Node.js `pino` logger, which doesn’t work in the browser.

### What I Did

* Added a lightweight browser-safe `logger.js` inside each Svelte example (`src/lib/logger.js`)
* Replaced imports of the Node logger with the new local browser logger

### Result

All Svelte examples run correctly in the browser without relying on `pino`.
