### PR TITLE
fix: integration tests

### DIFF
--- a/lib/backup-car.js
+++ b/lib/backup-car.js
@@ -31,6 +31,7 @@ import {
   downloadBlockFromIPFSNetwork,
   downloadBlockFromStoracha,
 } from "./orbitdb-storacha-bridge.js";
+import { unixfs } from "@helia/unixfs";
 import logger from "./logger.js";
 
 /**
@@ -426,8 +427,7 @@ export async function listAvailableBackups(options = {}) {
       // Try network download first if enabled and IPFS instance available
       if (config.useIPFSNetwork && config.ipfs) {
         try {
-          const { unixfs: unixfsModule } = await import("@helia/unixfs");
-          const fs = unixfsModule(config.ipfs);
+          const fs = unixfs(config.ipfs);
           const bytes = await downloadBlockFromIPFSNetwork(cid, config.ipfs, {
             ...config,
             unixfs: fs,
@@ -710,8 +710,7 @@ export async function restoreFromSpaceCAR(orbitdb, options = {}) {
             "   🌐 Attempting to download metadata from IPFS network...",
           );
           // Get unixfs from orbitdb if available (it should be from createHeliaOrbitDB)
-          const { unixfs: unixfsModule } = await import("@helia/unixfs");
-          const fs = unixfsModule(orbitdb.ipfs);
+          const fs = unixfs(orbitdb.ipfs);
           metadataBytes = await downloadBlockFromIPFSNetwork(
             metadataCID,
             orbitdb.ipfs,
@@ -782,8 +781,7 @@ export async function restoreFromSpaceCAR(orbitdb, options = {}) {
         // Use provided unixfs or create one from orbitdb
         let fs = config.unixfs;
         if (!fs) {
-          const { unixfs: unixfsModule } = await import("@helia/unixfs");
-          fs = unixfsModule(orbitdb.ipfs);
+          fs = unixfs(orbitdb.ipfs);
         }
         carBytes = await downloadBlockFromIPFSNetwork(carCID, orbitdb.ipfs, {
           ...config,

--- a/lib/orbitdb-storacha-bridge.js
+++ b/lib/orbitdb-storacha-bridge.js
@@ -443,7 +443,62 @@ async function uploadBlocksToStoracha(
         size: blockData.bytes.length,
       };
     } catch (error) {
-      logger.error(`   ❌ Failed to upload block ${hash}: ${error.message}`);
+      // Enhanced error handling for rate limits and service errors
+      let errorMessage = error.message;
+      let rateLimitInfo = "";
+
+      // Check if it's a rate limit or service error with retry info
+      if (error.status === 503 || error.code === 503) {
+        const retryAfter = error.headers?.get?.("Retry-After") || error["retry-after"];
+        const rateLimitReset = error.headers?.get?.("X-RateLimit-Reset") || error["x-ratelimit-reset"];
+        const rateLimitRemaining = error.headers?.get?.("X-RateLimit-Remaining") || error["x-ratelimit-remaining"];
+
+        rateLimitInfo += `\n   📊 Service Status: 503 Service Unavailable (rate limited or maintenance)`;
+
+        if (retryAfter) {
+          const retrySeconds = parseInt(retryAfter);
+          let retryTime = retryAfter;
+          if (!isNaN(retrySeconds)) {
+            const futureTime = new Date(Date.now() + retrySeconds * 1000);
+            retryTime = `${retrySeconds} seconds (available at ${futureTime.toLocaleTimeString()})`;
+          } else {
+            // Try to parse as HTTP date
+            const retryDate = new Date(retryAfter);
+            if (!isNaN(retryDate.getTime())) {
+              const waitMs = Math.max(0, retryDate.getTime() - Date.now());
+              const waitSecs = Math.ceil(waitMs / 1000);
+              retryTime = `${waitSecs} seconds (available at ${retryDate.toLocaleTimeString()})`;
+            }
+          }
+          rateLimitInfo += `\n   ⏱️  Retry-After: ${retryTime}`;
+        }
+
+        if (rateLimitReset) {
+          const resetTime = parseInt(rateLimitReset);
+          if (!isNaN(resetTime)) {
+            const resetDate = new Date(resetTime * 1000);
+            const waitMs = Math.max(0, resetDate.getTime() - Date.now());
+            const waitSecs = Math.ceil(waitMs / 1000);
+            rateLimitInfo += `\n   🔄 Rate Limit Reset: ${resetDate.toLocaleTimeString()} (in ${waitSecs}s)`;
+          }
+        }
+
+        if (rateLimitRemaining) {
+          rateLimitInfo += `\n   📈 Requests Remaining: ${rateLimitRemaining}`;
+        }
+
+        if (!retryAfter && !rateLimitReset) {
+          rateLimitInfo += `\n   💡 No retry timing provided - service may be temporarily unavailable`;
+        }
+
+        errorMessage = `${errorMessage}${rateLimitInfo}`;
+      } else if (error.status || error.code) {
+        // Other HTTP errors
+        const statusCode = error.status || error.code;
+        errorMessage = `HTTP ${statusCode}: ${errorMessage}`;
+      }
+
+      logger.error(`   ❌ Failed to upload block ${hash}: ${errorMessage}`);
 
       // Update progress even for failed uploads
       completedBlocks++;
@@ -941,7 +996,7 @@ export async function clearStorachaSpace(options = {}) {
  */
 export async function downloadBlockFromIPFSNetwork(cid, helia, options = {}) {
   const config = { ...DEFAULT_OPTIONS, ...options };
-  
+
   try {
     // Check if helia instance is available and ready
     if (!helia) {
@@ -949,10 +1004,10 @@ export async function downloadBlockFromIPFSNetwork(cid, helia, options = {}) {
     }
 
     const parsedCID = typeof cid === "string" ? CID.parse(cid) : cid;
-    
+
     // Create unixfs instance from helia (or use provided one)
     const fs = options.unixfs || unixfs(helia);
-    
+
     // Use unixfs.cat() to get complete content (handles DAGs automatically)
     // This uses Bitswap protocol to fetch from IPFS network and traverses DAGs
     const chunks = [];
@@ -1083,9 +1138,52 @@ export async function downloadBlockFromStoracha(storachaCID, options = {}) {
         logger.info(`   ✅ Downloaded ${bytes.length} bytes from ${gateway}`);
         return bytes;
       } else {
-        logger.debug(
-          `   ⚠️ Gateway ${gateway} returned status ${response.status}, trying next gateway...`,
-        );
+        // Enhanced logging for 503 and other error statuses
+        let errorLog = `   ⚠️ Gateway ${gateway} returned status ${response.status}`;
+
+        if (response.status === 503) {
+          const retryAfter = response.headers?.get("Retry-After");
+          const rateLimitReset = response.headers?.get("X-RateLimit-Reset");
+          const rateLimitRemaining = response.headers?.get("X-RateLimit-Remaining");
+
+          errorLog += ` (Service Unavailable - likely rate limited)`;
+
+          if (retryAfter) {
+            const retrySeconds = parseInt(retryAfter);
+            if (!isNaN(retrySeconds)) {
+              const futureTime = new Date(Date.now() + retrySeconds * 1000);
+              errorLog += `\n           ⏱️ Retry-After: ${retrySeconds}s (available at ${futureTime.toLocaleTimeString()})`;
+            } else {
+              const retryDate = new Date(retryAfter);
+              if (!isNaN(retryDate.getTime())) {
+                const waitSecs = Math.ceil(
+                  Math.max(0, retryDate.getTime() - Date.now()) / 1000,
+                );
+                errorLog += `\n           ⏱️ Retry-After: ${waitSecs}s (available at ${retryDate.toLocaleTimeString()})`;
+              } else {
+                errorLog += `\n           ⏱️ Retry-After: ${retryAfter}`;
+              }
+            }
+          }
+
+          if (rateLimitReset) {
+            const resetTime = parseInt(rateLimitReset);
+            if (!isNaN(resetTime)) {
+              const resetDate = new Date(resetTime * 1000);
+              const waitSecs = Math.ceil(
+                Math.max(0, resetDate.getTime() - Date.now()) / 1000,
+              );
+              errorLog += `\n           🔄 Rate Limit Reset: ${resetDate.toLocaleTimeString()} (in ${waitSecs}s)`;
+            }
+          }
+
+          if (rateLimitRemaining !== null && rateLimitRemaining !== undefined) {
+            errorLog += `\n           📈 Requests Remaining: ${rateLimitRemaining}`;
+          }
+        }
+
+        errorLog += `, trying next gateway...`;
+        logger.debug(errorLog);
       }
     } catch (error) {
       logger.debug(`   ⚠️ Failed from ${gateway}: ${error.message}`);
@@ -1288,7 +1386,9 @@ async function downloadAndBridgeBlocks(
         }
 
         blockBytes = new Uint8Array(await response.arrayBuffer());
-        logger.info(`   ✅ Downloaded ${blockBytes.length} bytes from gateway ${config.gateway}`);
+        logger.info(
+          `   ✅ Downloaded ${blockBytes.length} bytes from gateway ${config.gateway}`,
+        );
       }
 
       // Convert Storacha CID to OrbitDB format
@@ -2369,7 +2469,9 @@ async function downloadBlocksWithProgress(
 
       // Store in target blockstore with error handling for closed blockstore
       if (!currentOrbitDB?.ipfs?.blockstore) {
-        throw new Error("Blockstore is not available - OrbitDB may have been closed");
+        throw new Error(
+          "Blockstore is not available - OrbitDB may have been closed",
+        );
       }
       try {
         await currentOrbitDB.ipfs.blockstore.put(parsedCID, bytes);

--- a/lib/orbitdb-storacha-bridge.js
+++ b/lib/orbitdb-storacha-bridge.js
@@ -22,6 +22,7 @@ import {
   findLatestBackup,
 } from "./backup-helpers.js";
 import { logger } from "./logger.js";
+import { unixfs } from "@helia/unixfs";
 
 /**
  * Default configuration options
@@ -940,24 +941,18 @@ export async function clearStorachaSpace(options = {}) {
  */
 export async function downloadBlockFromIPFSNetwork(cid, helia, options = {}) {
   const config = { ...DEFAULT_OPTIONS, ...options };
-  const { CID } = await import("multiformats/cid");
-  const { unixfs: unixfsModule } = await import("@helia/unixfs");
-
+  
   try {
     // Check if helia instance is available and ready
     if (!helia) {
       throw new Error("Helia instance is not available");
     }
 
-    // Note: libp2p should already be started when helia is created
-    // If it's not started, the network operation will fail and fall back to gateway
-    // No need to check isStarted() as it doesn't exist in the libp2p API
-
     const parsedCID = typeof cid === "string" ? CID.parse(cid) : cid;
-
+    
     // Create unixfs instance from helia (or use provided one)
-    const fs = options.unixfs || unixfsModule(helia);
-
+    const fs = options.unixfs || unixfs(helia);
+    
     // Use unixfs.cat() to get complete content (handles DAGs automatically)
     // This uses Bitswap protocol to fetch from IPFS network and traverses DAGs
     const chunks = [];
@@ -1134,7 +1129,21 @@ export async function analyzeBlocks(blockstore, downloadedBlocks = null) {
         throw new Error("Blockstore is not available or accessible");
       }
 
-      const bytes = await blockstore.get(cid);
+      let bytes;
+      try {
+        bytes = await blockstore.get(cid);
+      } catch (error) {
+        if (
+          error.message?.includes("not open") ||
+          error.message?.includes("closed") ||
+          error.message?.includes("Database is not open")
+        ) {
+          throw new Error(
+            `Blockstore operation failed - OrbitDB was closed during analysis: ${error.message}`,
+          );
+        }
+        throw error;
+      }
 
       if (cid.code === 0x71) {
         // dag-cbor codec
@@ -1246,8 +1255,7 @@ async function downloadAndBridgeBlocks(
         try {
           // Create unixfs if not provided
           if (!config.unixfs) {
-            const { unixfs: unixfsModule } = await import("@helia/unixfs");
-            config.unixfs = unixfsModule(config.helia);
+            config.unixfs = unixfs(config.helia);
           }
           blockBytes = await downloadBlockFromIPFSNetwork(
             storachaCID,
@@ -1280,7 +1288,7 @@ async function downloadAndBridgeBlocks(
         }
 
         blockBytes = new Uint8Array(await response.arrayBuffer());
-        logger.info(`   ✅ Downloaded ${blockBytes.length} bytes from gateway`);
+        logger.info(`   ✅ Downloaded ${blockBytes.length} bytes from gateway ${config.gateway}`);
       }
 
       // Convert Storacha CID to OrbitDB format
@@ -2359,8 +2367,24 @@ async function downloadBlocksWithProgress(
       const orbitdbCID = convertStorachaCIDToOrbitDB(storachaCID);
       const parsedCID = CID.parse(orbitdbCID);
 
-      // Store in target blockstore
-      await currentOrbitDB.ipfs.blockstore.put(parsedCID, bytes);
+      // Store in target blockstore with error handling for closed blockstore
+      if (!currentOrbitDB?.ipfs?.blockstore) {
+        throw new Error("Blockstore is not available - OrbitDB may have been closed");
+      }
+      try {
+        await currentOrbitDB.ipfs.blockstore.put(parsedCID, bytes);
+      } catch (error) {
+        if (
+          error.message?.includes("not open") ||
+          error.message?.includes("closed") ||
+          error.message?.includes("Database is not open")
+        ) {
+          throw new Error(
+            `Blockstore operation failed - OrbitDB was closed during download: ${error.message}`,
+          );
+        }
+        throw error;
+      }
       downloadedBlocks.set(orbitdbCID, { storachaCID, bytes: bytes.length });
 
       logger.info(`   ✅ Stored: ${orbitdbCID}`);

--- a/lib/ucan-bridge.js
+++ b/lib/ucan-bridge.js
@@ -782,7 +782,9 @@ async function downloadBlocksWithProgressUCAN(
 
       // Store in target blockstore with error handling for closed blockstore
       if (!currentOrbitDB?.ipfs?.blockstore) {
-        throw new Error("Blockstore is not available - OrbitDB may have been closed");
+        throw new Error(
+          "Blockstore is not available - OrbitDB may have been closed",
+        );
       }
       try {
         await currentOrbitDB.ipfs.blockstore.put(parsedCID, bytes);

--- a/lib/ucan-bridge.js
+++ b/lib/ucan-bridge.js
@@ -780,7 +780,24 @@ async function downloadBlocksWithProgressUCAN(
       const orbitdbCID = convertStorachaCIDToOrbitDB(storachaCID);
       const parsedCID = CID.parse(orbitdbCID);
 
-      await currentOrbitDB.ipfs.blockstore.put(parsedCID, bytes);
+      // Store in target blockstore with error handling for closed blockstore
+      if (!currentOrbitDB?.ipfs?.blockstore) {
+        throw new Error("Blockstore is not available - OrbitDB may have been closed");
+      }
+      try {
+        await currentOrbitDB.ipfs.blockstore.put(parsedCID, bytes);
+      } catch (error) {
+        if (
+          error.message?.includes("not open") ||
+          error.message?.includes("closed") ||
+          error.message?.includes("Database is not open")
+        ) {
+          throw new Error(
+            `Blockstore operation failed - OrbitDB was closed during download: ${error.message}`,
+          );
+        }
+        throw error;
+      }
       downloadedBlocks.set(orbitdbCID, { storachaCID, bytes: bytes.length });
 
       logger.info(`   ✅ Stored (UCAN): ${orbitdbCID}`);

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -126,7 +126,7 @@ async function waitForPeers(heliaNode, minPeers = 1, timeout = 30000) {
  * @namespace OrbitDBStorachaBridgeIntegration
  * @description Integration test suite for OrbitDB Storacha Bridge functionality
  */
-describe.only("OrbitDB Storacha Bridge Integration", () => {
+describe("OrbitDB Storacha Bridge Integration", () => {
   /** @type {Object|null} Source OrbitDB node instance */
   let sourceNode;
   /** @type {Object|null} Target OrbitDB node instance */
@@ -190,7 +190,7 @@ describe.only("OrbitDB Storacha Bridge Integration", () => {
   afterEach(async () => {
     // Give a moment for any pending operations to complete
     await new Promise((resolve) => setTimeout(resolve, 1000));
-    
+
     // Cleanup nodes
     const nodes = [sourceNode, targetNode].filter(Boolean);
     for (const node of nodes) {
@@ -1019,7 +1019,7 @@ describe.only("OrbitDB Storacha Bridge Integration", () => {
         }
       }
     }
-  }, 300000); // 5 minute timeout for network operations
+  }, 420000); // 7 minute timeout for network operations
 
   /**
    * @test DocumentsDELOperationsRestore

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -126,7 +126,7 @@ async function waitForPeers(heliaNode, minPeers = 1, timeout = 30000) {
  * @namespace OrbitDBStorachaBridgeIntegration
  * @description Integration test suite for OrbitDB Storacha Bridge functionality
  */
-describe("OrbitDB Storacha Bridge Integration", () => {
+describe.only("OrbitDB Storacha Bridge Integration", () => {
   /** @type {Object|null} Source OrbitDB node instance */
   let sourceNode;
   /** @type {Object|null} Target OrbitDB node instance */
@@ -188,15 +188,28 @@ describe("OrbitDB Storacha Bridge Integration", () => {
    * Handles cleanup errors gracefully to prevent test interference.
    */
   afterEach(async () => {
+    // Give a moment for any pending operations to complete
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+    
     // Cleanup nodes
     const nodes = [sourceNode, targetNode].filter(Boolean);
     for (const node of nodes) {
       try {
-        await node.orbitdb.stop();
-        await node.helia.stop();
-        await node.blockstore.close();
-        await node.datastore.close();
+        // Check if node is still valid before closing
+        if (node.orbitdb && typeof node.orbitdb.stop === "function") {
+          await node.orbitdb.stop();
+        }
+        if (node.helia && typeof node.helia.stop === "function") {
+          await node.helia.stop();
+        }
+        if (node.blockstore && typeof node.blockstore.close === "function") {
+          await node.blockstore.close();
+        }
+        if (node.datastore && typeof node.datastore.close === "function") {
+          await node.datastore.close();
+        }
       } catch (error) {
+        // Ignore cleanup errors - node may already be closed
         logger.warn("Cleanup warning:", error.message);
       }
     }
@@ -339,7 +352,7 @@ describe("OrbitDB Storacha Bridge Integration", () => {
         }
       }
     }
-  }, 120000); // 2 minute timeout for network operations
+  }, 240000); // 4 minute timeout for network operations
 
   /**
    * @test MappingIndependentRestore
@@ -463,7 +476,7 @@ describe("OrbitDB Storacha Bridge Integration", () => {
         }
       }
     }
-  }, 120000); // 2 minute timeout for network operations
+  }, 240000); // 4 minute timeout for network operations
 
   /**
    * @test KeyValueMappingIndependentRestore
@@ -687,7 +700,7 @@ describe("OrbitDB Storacha Bridge Integration", () => {
         }
       }
     }
-  }, 120000); // 2 minute timeout for network operations
+  }, 300000); // 5 minute timeout for network operations
 
   /**
    * @test KeyValueDELOperationsRestore
@@ -1006,7 +1019,7 @@ describe("OrbitDB Storacha Bridge Integration", () => {
         }
       }
     }
-  }, 120000); // 2 minute timeout for network operations
+  }, 300000); // 5 minute timeout for network operations
 
   /**
    * @test DocumentsDELOperationsRestore
@@ -1180,7 +1193,7 @@ describe("OrbitDB Storacha Bridge Integration", () => {
         }
       }
     }
-  }, 120000); // 2 minute timeout for network operations
+  }, 300000); // 5 minute timeout for network operations
 
   /**
    * @test CIDConversionUtilities


### PR DESCRIPTION
only integration tests are enabled


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Use direct @helia/unixfs across network paths, improve rate-limit/gateway logging and blockstore error handling, and make tests more reliable with longer timeouts and safer cleanup.
> 
> - **Networking/IPFS**:
>   - Replace dynamic imports with direct `unixfs` usage in `downloadBlockFromIPFSNetwork`, CAR metadata/CAR downloads, and block downloads.
>   - Enhance gateway/error logging with rate-limit details (Retry-After, reset/remaining) and clearer messages.
>   - Add safeguards for blockstore operations (detect closed/not open) during get/put in analysis and downloads.
> - **Storacha/Bridge**:
>   - Improve upload error handling (503/rate-limit introspection) and messages.
>   - Update gateway download logs to include selected gateway and status details.
> - **UCAN bridge**:
>   - Add blockstore closed-state handling during restore storage writes.
> - **Tests**:
>   - Increase timeouts for long-running integration tests; add brief post-test delay and defensive shutdowns in `afterEach`.
>   - Add `jest.restoreAllMocks()` in network restore tests; remove the no-fallback failure test.
>   - Minor logging tweaks and peer-wait helpers retained for stability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d692f1da4d07d19b1bf14608704ad3dce947a882. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->