### PR TITLE
feat: add persistent service DID to in-memory Storacha helper

### DIFF
--- a/test/helpers/in-memory-storacha.js
+++ b/test/helpers/in-memory-storacha.js
@@ -1,4 +1,6 @@
 import http from "node:http";
+import fs from "node:fs";
+import path from "node:path";
 import * as client from "@ucanto/client";
 import { createHelia } from "helia";
 import { unixfs } from "@helia/unixfs";
@@ -278,6 +280,84 @@ function createCorsHttp() {
         return handler(req, res);
       }),
   };
+}
+
+async function getOrCreateServiceSigner({
+  persist = false,
+  signerPath,
+  defaultDid,
+} = {}) {
+  if (!persist) {
+    const signer = await ed25519.generate();
+    return defaultDid ? signer.withDID(defaultDid) : signer;
+  }
+
+  const file = signerPath || path.resolve(".tmp/in-memory-service-did.json");
+
+  try {
+    if (fs.existsSync(file)) {
+      const data = JSON.parse(fs.readFileSync(file, "utf8"));
+      if (typeof data.privateKey === "string") {
+        let signer = ed25519.parse(data.privateKey);
+        if (defaultDid) {
+          signer = signer.withDID(defaultDid);
+        }
+        serverLogger(
+          colorize(
+            colors.teal,
+            `🌐 Using persisted service DID: ${signer.did()} (key: ${signer.toDIDKey()})`,
+          ),
+        );
+        return signer;
+      }
+    }
+  } catch (err) {
+    serverLogger(
+      colorize(
+        colors.teal,
+        `⚠️ [in-memory-storacha] failed to load persisted signer: ${err.message}`,
+      ),
+    );
+  }
+
+  const signer = await ed25519.generate();
+  const finalSigner = defaultDid ? signer.withDID(defaultDid) : signer;
+  serverLogger(
+    colorize(
+      colors.teal,
+      `🌐 Generated fresh service DID: ${finalSigner.did()} (key: ${finalSigner.toDIDKey()})`,
+    ),
+  );
+
+  try {
+    fs.mkdirSync(path.dirname(file), { recursive: true });
+    fs.writeFileSync(
+      file,
+      JSON.stringify(
+        {
+          did: finalSigner.did(),
+          key: finalSigner.toDIDKey(),
+          privateKey: ed25519.format(signer),
+          createdAt: new Date().toISOString(),
+        },
+        null,
+        2,
+      ),
+      "utf8",
+    );
+    serverLogger(
+      colorize(colors.teal, `🌐 Persisted service DID to: ${file}`),
+    );
+  } catch (err) {
+    serverLogger(
+      colorize(
+        colors.teal,
+        `⚠️ [in-memory-storacha] failed to persist signer: ${err.message}`,
+      ),
+    );
+  }
+
+  return finalSigner;
 }
 
 async function startUploadApiServer(context) {
@@ -562,13 +642,23 @@ function buildServiceConf(url, serviceDid) {
   };
 }
 
-export async function startInMemoryStorachaService() {
+export async function startInMemoryStorachaService(options = {}) {
   await ensureHelia();
   const gateway = await startGatewayServer();
   const context = await createContext({
     requirePaymentPlan: false,
     http: createCorsHttp(),
   });
+
+  const signer = await getOrCreateServiceSigner({
+    persist: options.persistServiceDid === true,
+    signerPath: options.serviceDidPath,
+    defaultDid: context.id.did(),
+  });
+
+  context.id = signer;
+  context.signer = signer;
+
   const { server, url } = await startUploadApiServer(context);
   const credentials = await createLocalCredentials(context);
   const serviceConf = buildServiceConf(url, context.id.did());

--- a/test/service-persistence.test.js
+++ b/test/service-persistence.test.js
@@ -1,0 +1,81 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  startInMemoryStorachaService,
+  stopInMemoryStorachaService,
+} from './helpers/in-memory-storacha.js';
+
+describe('Storacha In-memory Service Persistence', () => {
+  const signerPath = path.resolve('.tmp/test-service-did.json');
+
+  beforeEach(() => {
+    if (fs.existsSync(signerPath)) {
+      fs.unlinkSync(signerPath);
+    }
+  });
+
+  afterAll(async () => {
+    if (fs.existsSync(signerPath)) {
+      fs.unlinkSync(signerPath);
+    }
+    try {
+      const tmpDir = path.dirname(signerPath);
+      if (fs.readdirSync(tmpDir).length === 0) {
+        fs.rmdirSync(tmpDir);
+      }
+    } catch (err) {
+    }
+  });
+
+  it('should reuse the same service DID key when persistence is enabled', async () => {
+    const service1 = await startInMemoryStorachaService({
+      persistServiceDid: true,
+      serviceDidPath: signerPath,
+    });
+    const key1 = service1.context.id.toDIDKey();
+    const did1 = service1.context.id.did();
+    await stopInMemoryStorachaService(service1);
+
+    const service2 = await startInMemoryStorachaService({
+      persistServiceDid: true,
+      serviceDidPath: signerPath,
+    });
+    const key2 = service2.context.id.toDIDKey();
+    const did2 = service2.context.id.did();
+    await stopInMemoryStorachaService(service2);
+
+    expect(did1).toBe(did2);
+    expect(key1).toBe(key2);
+    expect(fs.existsSync(signerPath)).toBe(true);
+  });
+
+  it('should rotate DID key by default (persistence disabled)', async () => {
+    const service1 = await startInMemoryStorachaService();
+    const key1 = service1.context.id.toDIDKey();
+    await stopInMemoryStorachaService(service1);
+
+    const service2 = await startInMemoryStorachaService();
+    const key2 = service2.context.id.toDIDKey();
+    await stopInMemoryStorachaService(service2);
+
+    expect(key1).not.toBe(key2);
+  });
+
+  it('should rotate DID key when persistence is disabled even if path is provided', async () => {
+    const service1 = await startInMemoryStorachaService({
+      persistServiceDid: false,
+      serviceDidPath: signerPath,
+    });
+    const key1 = service1.context.id.toDIDKey();
+    await stopInMemoryStorachaService(service1);
+
+    const service2 = await startInMemoryStorachaService({
+      persistServiceDid: false,
+      serviceDidPath: signerPath,
+    });
+    const key2 = service2.context.id.toDIDKey();
+    await stopInMemoryStorachaService(service2);
+
+    expect(key1).not.toBe(key2);
+  });
+});


### PR DESCRIPTION
This PR introduces the ability to maintain a stable Service DID for the in-memory Storacha `upload-api` helper across restarts. Currently, the service generates a fresh identity on every startup, which can break local development workflows or tests that rely on a consistent service identity.

**Changes**
- **Persistent Signer Helper**: Added `getOrCreateServiceSigner` in [in-memory-storacha.js](file:///d:/orbitdb-storacha-bridge/test/helpers/in-memory-storacha.js) to handle loading and saving Ed25519 keys to a local JSON file (defaults to `.tmp/in-memory-service-did.json`).
- **Opt-in Configuration**: Updated `startInMemoryStorachaService` to accept `persistServiceDid` (boolean) and `serviceDidPath` (string) options.
- **DID Identity Preservation**: Ensured that even when using a persisted key, the service maintains the expected `did:web:test.up.storacha.network` identity required by UCAN capability validation.
- **Enhanced Logging**: Added clear console output to indicate whether the service is using a persisted identity or a freshly generated one.
- **Validation Suite**: Added [service-persistence.test.js](file:///d:/orbitdb-storacha-bridge/test/service-persistence.test.js) to verify DID stability in persisted mode and ensure default rotation behavior remains unchanged.

**How to Test**
You can now enable persistence in your local tests or dev environment:
```javascript
const service = await startInMemoryStorachaService({ 
  persistServiceDid: true 
});
```

**Checklist**
- [x] Persistence is opt-in and defaults to false (CI compatible)
- [x] Existing integration tests pass
- [x] New tests added for DID stability
- [x] Logging provides clear visibility into identity status


Closes #46 